### PR TITLE
change language level for maven build plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,15 @@
 		<testSourceDirectory>test</testSourceDirectory>
 
 		<plugins>
+     			 <plugin>
+        			<groupId>org.apache.maven.plugins</groupId>
+        			<artifactId>maven-compiler-plugin</artifactId>
+        			<version>3.1</version>
+        			<configuration>
+          				<source>1.5</source>
+          				<target>1.5</target>
+        			</configuration>
+      			</plugin>
 			<!-- Disable resources (project has none) -->
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>


### PR DESCRIPTION
```
[ERROR] (use -source 5 or higher to enable generics)
[ERROR] /home/dimzon/git/reflectasm/src/com/esotericsoftware/reflectasm/MethodAccess.java:[281,27] error: for-each loops are not supported in -source 1.3
[ERROR] 
[ERROR] (use -source 5 or higher to enable for-each loops)
[ERROR] /home/dimzon/git/reflectasm/src/com/esotericsoftware/reflectasm/FieldAccess.java:[4,7] error: static import declarations are not supported in -source 1.3
[ERROR] 
[ERROR] (use -source 5 or higher to enable static import declarations)
[ERROR] /home/dimzon/git/reflectasm/src/com/esotericsoftware/reflectasm/FieldAccess.java:[84,11] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR] (use -source 5 or higher to enable generics)
[ERROR] /home/dimzon/git/reflectasm/src/com/esotericsoftware/reflectasm/AccessClassLoader.java:[14,33] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR] (use -source 5 or higher to enable generics)
[ERROR] /home/dimzon/git/reflectasm/src/com/esotericsoftware/reflectasm/ConstructorAccess.java:[4,7] error: static import declarations are not supported in -source 1.3
```
