### PR TITLE
Removes sychronization of AccessClassLoader.loadClass

### DIFF
--- a/src/com/esotericsoftware/reflectasm/AccessClassLoader.java
+++ b/src/com/esotericsoftware/reflectasm/AccessClassLoader.java
@@ -82,7 +82,7 @@ class AccessClassLoader extends ClassLoader {
 		super(parent);
 	}
 
-	protected synchronized java.lang.Class<?> loadClass (String name, boolean resolve) throws ClassNotFoundException {
+	protected java.lang.Class<?> loadClass (String name, boolean resolve) throws ClassNotFoundException {
 		// These classes come from the classloader that loaded AccessClassLoader.
 		if (name.equals(FieldAccess.class.getName())) return FieldAccess.class;
 		if (name.equals(MethodAccess.class.getName())) return MethodAccess.class;


### PR DESCRIPTION
The finally delegated `ClassLoader.loadClass` still sychronizes (more fine grained) on the class name this should be safe, because `AccessClassLoader.loadClass` itself does not mutate anything.

Refs EsotericSoftware/kryo#422