### PR TITLE
Fix license references to the 3-Clause BSD License

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-Project license(s): New BSD License
+Project license(s): 3-Clause BSD License
 
 * You will only Submit Contributions where You have authored 100% of the content.
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 	<licenses>
 		<license>
 			<name>New BSD License</name>
-			<url>http://www.opensource.org/licenses/bsd-license.php</url>
+			<url>https://opensource.org/licenses/BSD-3-Clause</url>
 			<distribution>repo</distribution>
 		</license>
 	</licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
 	<licenses>
 		<license>
-			<name>New BSD License</name>
+			<name>3-Clause BSD License</name>
 			<url>https://opensource.org/licenses/BSD-3-Clause</url>
 			<distribution>repo</distribution>
 		</license>


### PR DESCRIPTION
@NathanSweet Same fix as https://github.com/EsotericSoftware/minlog/pull/6.