### PR TITLE
Allow the Object class to be used with MethodAccess#get(Class)

### DIFF
--- a/src/com/esotericsoftware/reflectasm/MethodAccess.java
+++ b/src/com/esotericsoftware/reflectasm/MethodAccess.java
@@ -82,8 +82,8 @@ public abstract class MethodAccess {
 	 * @param type Must not be the Object class, a primitive type, or void. */
 	static public MethodAccess get (Class type) {
 		boolean isInterface = type.isInterface();
-		if (!isInterface && type.getSuperclass() == null)
-			throw new IllegalArgumentException("The type must not be the Object class, an interface, a primitive type, or void.");
+		if (!isInterface && type.getSuperclass() == null && type != Object.class)
+			throw new IllegalArgumentException("The type must not be an interface, a primitive type, or void.");
 
 		ArrayList<Method> methods = new ArrayList<Method>();
 		if (!isInterface) {

--- a/src/com/esotericsoftware/reflectasm/MethodAccess.java
+++ b/src/com/esotericsoftware/reflectasm/MethodAccess.java
@@ -79,7 +79,7 @@ public abstract class MethodAccess {
 	}
 
 	/** Creates a new MethodAccess for the specified type.
-	 * @param type Must not be the Object class, a primitive type, or void. */
+	 * @param type Must not be a primitive type, or void. */
 	static public MethodAccess get (Class type) {
 		boolean isInterface = type.isInterface();
 		if (!isInterface && type.getSuperclass() == null && type != Object.class)


### PR DESCRIPTION
As part of [#ade0542 ](https://github.com/EsotericSoftware/reflectasm/commit/54f453484e2c94765d145b6c60c02df3bee74214#diff-293557efbc2146c85fa7512a9ca96292R83) primitive types, Void and the Object class were no longer allowed to be used with `MethodAccess#get(Class)`. This was done to mirror similar changes to `FieldAccess`  as a fix to #59.

But there actually seems to be no good reason to exclude the Object class, as there are legitimate use cases: For example [this](https://github.com/EsotericSoftware/kryonet/blob/master/test/com/esotericsoftware/kryonet/rmi/RmiTest.java) KryoNet test tries to invoke the `Object#hashCode()`-Method via RMI. This requires [`ObjectSpace`](https://github.com/EsotericSoftware/kryonet/blob/f9e4946047572a5d87a4a0f36622a1e6d83aacea/src/com/esotericsoftware/kryonet/rmi/ObjectSpace.java#L614) to use `MethodAccess#get(Class)`, where the class is `Object.class`.