### PR TITLE
support for multi-argument constructors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
         			<artifactId>maven-compiler-plugin</artifactId>
         			<version>3.1</version>
         			<configuration>
-          				<source>1.5</source>
-          				<target>1.5</target>
+          				<source>1.6</source>
+          				<target>1.6</target>
         			</configuration>
       			</plugin>
 			<!-- Disable resources (project has none) -->

--- a/test/com/esotericsoftware/reflectasm/ConstructorAccessTest.java
+++ b/test/com/esotericsoftware/reflectasm/ConstructorAccessTest.java
@@ -20,11 +20,15 @@ import junit.framework.TestCase;
 
 public class ConstructorAccessTest extends TestCase {
 	public void testNewInstance () {
-		ConstructorAccess<SomeClass> access = ConstructorAccess.get(SomeClass.class);
+		ConstructorAccess<SomeClass> access = ConstructorAccess.get(SomeClass.class, String.class, int.class, float.class, Float.class, String.class);
 		SomeClass someObject = new SomeClass();
+		SomeClass someObject0 = new SomeClass("11", 12, 13f, 14f, "15");
 		assertEquals(someObject, access.newInstance());
 		assertEquals(someObject, access.newInstance());
 		assertEquals(someObject, access.newInstance());
+		assertEquals(someObject0, access.newInstance0("11", 12, 13f, 14f, "15"));
+		assertEquals(someObject0, access.newInstance0("11", 12, 13f, 14f, "15"));
+		assertEquals(someObject0, access.newInstance0("11", 12, 13f, 14f, "15"));
 	}
 
 	public void testPackagePrivateNewInstance () {
@@ -132,6 +136,17 @@ public class ConstructorAccessTest extends TestCase {
 		protected float test1;
 		Float test2;
 		private String test3;
+
+		public SomeClass() {
+		}
+
+		public SomeClass(String name, int intValue, float test1, Float test2, String test3) {
+			this.name = name;
+			this.intValue = intValue;
+			this.test1 = test1;
+			this.test2 = test2;
+			this.test3 = test3;
+		}
 
 		public boolean equals (Object obj) {
 			if (this == obj) return true;

--- a/test/com/esotericsoftware/reflectasm/benchmark/ConstructorAccessBenchmark2.java
+++ b/test/com/esotericsoftware/reflectasm/benchmark/ConstructorAccessBenchmark2.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2008, Nathan Sweet
+ *  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package com.esotericsoftware.reflectasm.benchmark;
+
+import com.esotericsoftware.reflectasm.ConstructorAccess;
+
+import java.lang.reflect.Constructor;
+
+public class ConstructorAccessBenchmark2 extends Benchmark {
+	public ConstructorAccessBenchmark2() throws Exception {
+		int count = 1000000;
+		Object[] dontCompileMeAway = new Object[count];
+
+		Class type = SomeClass.class;
+		Constructor constructor = type.getDeclaredConstructor(String.class);
+		Constructor constructor0 = type.getDeclaredConstructor();
+		ConstructorAccess<SomeClass> access = ConstructorAccess.get(type, String.class);
+
+		for (int i = 0; i < 100; i++)
+			for (int ii = 0; ii < count; ii++)
+				dontCompileMeAway[ii] = access.newInstance0("11");
+		for (int i = 0; i < 100; i++)
+			for (int ii = 0; ii < count; ii++)
+				dontCompileMeAway[ii] = constructor.newInstance("11");
+		warmup = false;
+
+		for (int i = 0; i < 100; i++) {
+			start();
+			for (int ii = 0; ii < count; ii++)
+				dontCompileMeAway[ii] = access.newInstance0("11");
+			end("ConstructorAccess");
+		}
+		for (int i = 0; i < 100; i++) {
+			start();
+			for (int ii = 0; ii < count; ii++)
+				dontCompileMeAway[ii] = constructor.newInstance("11");
+			end("Constructor");
+		}
+
+		chart("Constructor");
+	}
+
+	static public class SomeClass {
+		public String name;
+
+		public SomeClass() {
+		}
+
+		public SomeClass(String name) {
+			this.name = name;
+		}
+	}
+
+	public static void main (String[] args) throws Exception {
+		new ConstructorAccessBenchmark2();
+	}
+}


### PR DESCRIPTION
add newInstance0() to support for multi-argument constructors
usage：
```
Constructor constructor = SomeClass.class.getConstructor(String.class);
ConstructorAccess<SomeClass> access = ConstructorAccess.get(SomeClass.class, constructor);
assertEquals(new SomeClass("coo), access.newInstance0("coo"));
```
bytecode:
```
public Object newInstance0(Object[] var1) {
    return new SomeClass((String)var1[0]);
}
```
Performance comparison of `access.newInstance("coo")` and `constructor.newInstance("coo")`

![](http://chart.apis.google.com/chart?chtt=Constructor&chs=700x57&chd=t:7871696,8874296&chds=0,8874296&chxl=0:|Constructor|ConstructorAccess&cht=bhg&chbh=10&chxt=y&chco=660000|660033|660066|660099|6600CC|6600FF|663300|663333|663366|663399|6633CC|6633FF|666600|666633|666666)
