### PR TITLE
Make generated FieldAccess class synthetic

### DIFF
--- a/src/com/esotericsoftware/reflectasm/FieldAccess.java
+++ b/src/com/esotericsoftware/reflectasm/FieldAccess.java
@@ -147,7 +147,7 @@ public abstract class FieldAccess {
 				String classNameInternal = className.replace('.', '/');
 
 				ClassWriter cw = new ClassWriter(0);
-				cw.visit(V1_6, ACC_PUBLIC + ACC_SUPER, accessClassNameInternal, null, "com/esotericsoftware/reflectasm/FieldAccess",
+				cw.visit(V1_6, ACC_PUBLIC + ACC_SUPER + ACC_SYNTHETIC, accessClassNameInternal, null, "com/esotericsoftware/reflectasm/FieldAccess",
 					null);
 				insertConstructor(cw);
 				insertGetObject(cw, classNameInternal, fields);


### PR DESCRIPTION
Should prevent a JaCoCo exception when its Java Agent tries to instrument the class
java.lang.instrument.IllegalClassFormatException: Error while instrumenting foo/bar/ApplicationStackFrameValueFieldAccess