### PR TITLE
Add support searching default methods since Java 8

### DIFF
--- a/src/com/esotericsoftware/reflectasm/MethodAccess.java
+++ b/src/com/esotericsoftware/reflectasm/MethodAccess.java
@@ -90,6 +90,9 @@ public abstract class MethodAccess {
 			Class nextClass = type;
 			while (nextClass != Object.class) {
 				addDeclaredMethodsToList(nextClass, methods);
+				for (Class nextInterface : nextClass.getInterfaces()) {
+					addDeclaredMethodsToList(nextInterface, methods);
+				}
 				nextClass = nextClass.getSuperclass();
 			}
 		} else


### PR DESCRIPTION
When using MethodAccess.get(Class type), I found that it can't find the default methods in interface("type" is not interface but implements an interface which have many default methods in it).