### PR TITLE
Use MethodHandles.Lookup.defineClass instead of java.lang.ClassLoader.defineClass

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.3</version>
+				<version>3.4.1</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -122,7 +122,7 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>2.5.0</version>
+				<version>5.1.8</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
         			<artifactId>maven-compiler-plugin</artifactId>
         			<version>3.1</version>
         			<configuration>
-          				<source>1.5</source>
-          				<target>1.5</target>
+          				<source>9</source>
+          				<target>9</target>
         			</configuration>
       			</plugin>
 			<!-- Disable resources (project has none) -->

--- a/src/com/esotericsoftware/reflectasm/AccessClassLoader.java
+++ b/src/com/esotericsoftware/reflectasm/AccessClassLoader.java
@@ -14,9 +14,8 @@
 
 package com.esotericsoftware.reflectasm;
 
+import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.ref.WeakReference;
-import java.lang.reflect.Method;
-import java.security.ProtectionDomain;
 import java.util.HashSet;
 import java.util.WeakHashMap;
 
@@ -30,8 +29,6 @@ class AccessClassLoader extends ClassLoader {
 	// Fast-path for classes loaded in the same ClassLoader as this class.
 	static private final ClassLoader selfContextParentClassLoader = getParentClassLoader(AccessClassLoader.class);
 	static private volatile AccessClassLoader selfContextAccessClassLoader = new AccessClassLoader(selfContextParentClassLoader);
-
-	static private volatile Method defineClassMethod;
 
 	private final HashSet<String> localClassNames = new HashSet();
 
@@ -52,9 +49,9 @@ class AccessClassLoader extends ClassLoader {
 		return null;
 	}
 
-	Class defineAccessClass (String name, byte[] bytes) throws ClassFormatError {
+	Class defineAccessClass (String name, byte[] bytes, Lookup lookup) throws ClassFormatError {
 		localClassNames.add(name);
-		return defineClass(name, bytes);
+		return defineClass(name, bytes, lookup);
 	}
 
 	protected Class<?> loadClass (String name, boolean resolve) throws ClassNotFoundException {
@@ -67,13 +64,14 @@ class AccessClassLoader extends ClassLoader {
 		return super.loadClass(name, resolve);
 	}
 
-	Class<?> defineClass (String name, byte[] bytes) throws ClassFormatError {
-		try {
-			// Attempt to load the access class in the same loader, which makes protected and default access members accessible.
-			return (Class<?>)getDefineClassMethod().invoke(getParent(),
-				new Object[] {name, bytes, Integer.valueOf(0), Integer.valueOf(bytes.length), getClass().getProtectionDomain()});
-		} catch (Exception ignored) {
-			// continue with the definition in the current loader (won't have access to protected and package-protected members)
+	Class<?> defineClass (String name, byte[] bytes, Lookup lookup) throws ClassFormatError {
+		if (lookup != null) {
+			try {
+				// Attempt to load the access class in the same loader, which makes protected and default access members accessible.
+				return lookup.defineClass(bytes);
+			} catch (Exception ignored) {
+				// continue with the definition in the current loader (won't have access to protected and package-protected members)
+			}
 		}
 		return defineClass(name, bytes, 0, bytes.length, getClass().getProtectionDomain());
 	}
@@ -99,22 +97,6 @@ class AccessClassLoader extends ClassLoader {
 		ClassLoader parent = type.getClassLoader();
 		if (parent == null) parent = ClassLoader.getSystemClassLoader();
 		return parent;
-	}
-
-	static private Method getDefineClassMethod () throws Exception {
-		if (defineClassMethod == null) {
-			synchronized (accessClassLoaders) {
-				if (defineClassMethod == null) {
-					defineClassMethod = ClassLoader.class.getDeclaredMethod("defineClass",
-						new Class[] {String.class, byte[].class, int.class, int.class, ProtectionDomain.class});
-					try {
-						defineClassMethod.setAccessible(true);
-					} catch (Exception ignored) {
-					}
-				}
-			}
-		}
-		return defineClassMethod;
 	}
 
 	static AccessClassLoader get (Class type) {

--- a/src/com/esotericsoftware/reflectasm/ConstructorAccess.java
+++ b/src/com/esotericsoftware/reflectasm/ConstructorAccess.java
@@ -16,6 +16,7 @@ package com.esotericsoftware.reflectasm;
 
 import static org.objectweb.asm.Opcodes.*;
 
+import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 
@@ -42,6 +43,10 @@ abstract public class ConstructorAccess<T> {
 	abstract public T newInstance (Object enclosingInstance);
 
 	static public <T> ConstructorAccess<T> get (Class<T> type) {
+		return get(type, null);
+	}
+
+	static public <T> ConstructorAccess<T> get (Class<T> type, Lookup lookup) {
 		Class enclosingType = type.getEnclosingClass();
 		boolean isNonStaticMemberClass = enclosingType != null && type.isMemberClass() && !Modifier.isStatic(type.getModifiers());
 
@@ -96,7 +101,7 @@ abstract public class ConstructorAccess<T> {
 				insertNewInstanceInner(cw, classNameInternal, enclosingClassNameInternal);
 
 				cw.visitEnd();
-				accessClass = loader.defineAccessClass(accessClassName, cw.toByteArray());
+				accessClass = loader.defineAccessClass(accessClassName, cw.toByteArray(), lookup);
 			}
 		}
 		ConstructorAccess<T> access;

--- a/src/com/esotericsoftware/reflectasm/FieldAccess.java
+++ b/src/com/esotericsoftware/reflectasm/FieldAccess.java
@@ -16,6 +16,7 @@ package com.esotericsoftware.reflectasm;
 
 import static org.objectweb.asm.Opcodes.*;
 
+import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -108,8 +109,12 @@ public abstract class FieldAccess {
 
 	abstract public float getFloat (Object instance, int fieldIndex);
 
-	/** @param type Must not be the Object class, an interface, a primitive type, or void. */
 	static public FieldAccess get (Class type) {
+		return get(type, (Lookup) null);
+	}
+
+	/** @param type Must not be the Object class, an interface, a primitive type, or void. */
+	static public FieldAccess get (Class type, Lookup lookup) {
 		if (type.getSuperclass() == null)
 			throw new IllegalArgumentException("The type must not be the Object class, an interface, a primitive type, or void.");
 
@@ -170,7 +175,7 @@ public abstract class FieldAccess {
 				insertSetPrimitive(cw, classNameInternal, fields, Type.CHAR_TYPE);
 				insertGetString(cw, classNameInternal, fields);
 				cw.visitEnd();
-				accessClass = loader.defineAccessClass(accessClassName, cw.toByteArray());
+				accessClass = loader.defineAccessClass(accessClassName, cw.toByteArray(), lookup);
 			}
 		}
 		try {

--- a/src/com/esotericsoftware/reflectasm/MethodAccess.java
+++ b/src/com/esotericsoftware/reflectasm/MethodAccess.java
@@ -16,6 +16,7 @@ package com.esotericsoftware.reflectasm;
 
 import static org.objectweb.asm.Opcodes.*;
 
+import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -78,9 +79,13 @@ public abstract class MethodAccess {
 		return returnTypes;
 	}
 
+	static public MethodAccess get (Class type) {
+		return get(type, null);
+	}
+
 	/** Creates a new MethodAccess for the specified type.
 	 * @param type Must not be a primitive type, or void. */
-	static public MethodAccess get (Class type) {
+	static public MethodAccess get (Class type, Lookup lookup) {
 		boolean isInterface = type.isInterface();
 		if (!isInterface && type.getSuperclass() == null && type != Object.class)
 			throw new IllegalArgumentException("The type must not be an interface, a primitive type, or void.");
@@ -273,7 +278,7 @@ public abstract class MethodAccess {
 				}
 				cw.visitEnd();
 				byte[] data = cw.toByteArray();
-				accessClass = loader.defineAccessClass(accessClassName, data);
+				accessClass = loader.defineAccessClass(accessClassName, data, lookup);
 			}
 		}
 		try {

--- a/test/com/esotericsoftware/reflectasm/ConstructorAccessTest.java
+++ b/test/com/esotericsoftware/reflectasm/ConstructorAccessTest.java
@@ -14,6 +14,7 @@
 
 package com.esotericsoftware.reflectasm;
 
+import java.lang.invoke.MethodHandles;
 import java.util.List;
 
 import junit.framework.TestCase;
@@ -38,8 +39,12 @@ public class ConstructorAccessTest extends TestCase {
 	}
 
 	public void testPackagePrivateNewInstance () {
-		if (java17) return;
-		ConstructorAccess<PackagePrivateClass> access = ConstructorAccess.get(PackagePrivateClass.class);
+		ConstructorAccess<PackagePrivateClass> access;
+		if (java17) {
+			access = ConstructorAccess.get(PackagePrivateClass.class, MethodHandles.lookup());
+		} else {
+			access = ConstructorAccess.get(PackagePrivateClass.class);
+		}
 		PackagePrivateClass someObject = new PackagePrivateClass();
 		assertEquals(someObject, access.newInstance());
 		assertEquals(someObject, access.newInstance());
@@ -71,9 +76,13 @@ public class ConstructorAccessTest extends TestCase {
 	}
 
 	public void testHasProtectedConstructor () {
-		if (java17) return;
 		try {
-			ConstructorAccess<HasProtectedConstructor> access = ConstructorAccess.get(HasProtectedConstructor.class);
+			ConstructorAccess<HasProtectedConstructor> access;
+			if (java17) {
+				access = ConstructorAccess.get(HasProtectedConstructor.class, MethodHandles.lookup());
+			} else {
+				access = ConstructorAccess.get(HasProtectedConstructor.class);
+			}
 			HasProtectedConstructor newInstance = access.newInstance();
 			assertEquals("cow", newInstance.getMoo());
 		} catch (Throwable t) {
@@ -83,9 +92,13 @@ public class ConstructorAccessTest extends TestCase {
 	}
 
 	public void testHasPackagePrivateConstructor () {
-		if (java17) return;
 		try {
-			ConstructorAccess<HasPackagePrivateConstructor> access = ConstructorAccess.get(HasPackagePrivateConstructor.class);
+			ConstructorAccess<HasPackagePrivateConstructor> access;
+			if (java17) {
+				access = ConstructorAccess.get(HasPackagePrivateConstructor.class, MethodHandles.lookup());
+			} else {
+				access = ConstructorAccess.get(HasPackagePrivateConstructor.class);
+			}
 			HasPackagePrivateConstructor newInstance = access.newInstance();
 			assertEquals("cow", newInstance.getMoo());
 		} catch (Throwable t) {


### PR DESCRIPTION
Note: this PR changes the minimum Java version 9. This may or may not be wanted...

I'm a bit unsure about this change. Especially the fallback case in `AccessClassLoader.defineClass` (which now always will happen if no `Lookup` is provided).